### PR TITLE
Surfacing boto functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ dataframe, execution_id = athena_client.execute(query="select * from my_table", 
 execution_id = athena_client.execute(query="select * from my_table", run_async=True) # Returns just the execution id 
 dataframe = athena_client.get_result(execution_id) # Will report errors if query failed or let you know if it is still running
 
+# With asynchronous queries, can check status, get error, or cancel
+pythena.get_query_status(execution_id)
+pythena.get_query_error(execution_id)
+pythena.cancel_query(execution_id)
+
 ```
 
 ## Note

--- a/pythena/Athena.py
+++ b/pythena/Athena.py
@@ -107,7 +107,7 @@ class Athena:
 
         # If failed, return error message
         elif res['QueryExecution']['Status']['State'] == 'FAILED':
-            raise Exceptions.QueryExecutionFailedException("Query failed with response: %s" % (get_query_error(query_execution_id)))
+            raise Exceptions.QueryExecutionFailedException("Query failed with response: %s" % (self.get_query_error(query_execution_id)))
         elif res['QueryExecution']['Status']['State'] == 'RUNNING':
             raise Exceptions.QueryStillRunningException("Query has not finished executing.")
         else: 
@@ -118,7 +118,7 @@ class Athena:
            wait_exponential_multiplier=300,
            wait_exponential_max=60 * 1000)
     def __poll_status(self, query_execution_id):
-        status = get_query_status(query_execution_id)
+        status = self.get_query_status(query_execution_id)
         if status in ['SUCCEEDED', 'FAILED']:
             return status
         else:

--- a/pythena/Athena.py
+++ b/pythena/Athena.py
@@ -107,7 +107,7 @@ class Athena:
 
         # If failed, return error message
         elif res['QueryExecution']['Status']['State'] == 'FAILED':
-            raise Exceptions.QueryExecutionFailedException("Query failed with response: %s" % (res['QueryExecution']['Status']['StateChangeReason']))
+            raise Exceptions.QueryExecutionFailedException("Query failed with response: %s" % (get_query_error(query_execution_id)))
         elif res['QueryExecution']['Status']['State'] == 'RUNNING':
             raise Exceptions.QueryStillRunningException("Query has not finished executing.")
         else: 
@@ -118,9 +118,7 @@ class Athena:
            wait_exponential_multiplier=300,
            wait_exponential_max=60 * 1000)
     def __poll_status(self, query_execution_id):
-        res = self.__athena.get_query_execution(QueryExecutionId=query_execution_id)
-        status = res['QueryExecution']['Status']['State']
-
+        status = get_query_status(query_execution_id)
         if status in ['SUCCEEDED', 'FAILED']:
             return status
         else:
@@ -138,4 +136,23 @@ class Athena:
         bucket = url.netloc
         path = url.path.lstrip('/')
         return bucket, path
+    
+    # A few functions to surface boto client functions to pythena: get status, get query error, and cancel a query
+    def get_query_status(self, query_execution_id):
+        res = self.__athena.get_query_execution(QueryExecutionId=query_execution_id)
+        return res['QueryExecution']['Status']['State']
+
+    def get_query_error(self, query_execution_id):
+        res = self.__athena.get_query_execution(QueryExecutionId=query_execution_id)
+        if res['QueryExecutionId']['Status']['State']=='FAILED':
+            return res['QueryExecution']['Status']['StateChangeReason']
+        else: 
+            return "Query has not failed: check status or see Athena log for more details"
+
+    def cancel_query(self, query_execution_id): 
+        self.__athena.stop_query_execution(QueryExecutionId=query_execution_id)
+        return 
+
+
+
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='pythena',
-    version='v1.1.0',
+    version='v1.2.0',
     license='Mozilla Public License Version 2.0',
     author='chris.pruitt',
     url='https://github.com/chrispruitt/pythena',


### PR DESCRIPTION
Small changes to allow easier access to boto client functions: get query status, get query error, and cancel query. Helpful if you're running things asynchronously. 