### PR TITLE
Enable usage of custom session object

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,15 @@ print(df.sample(n=2)) # Prints 2 rows from your dataframe
 
 ## Connect to Database
 ```python
+import boto3
 import pythena
 
 # Connect to a database
 athena_client = pythena.Athena(database="mydatabase")
 # Connect to a database and override default aws region in your aws configuration
 athena_client = pythena.Athena(database="mydatabase", region='us-east-1')
+# Connect to a database and override default profile in your aws configuration
+athena_client = pythena.Athena(database="mydatabase", session=boto3.session.Session())
 
 ```
 
@@ -53,18 +56,23 @@ execute(
 ## Full Usage Examples
 
 ```python
+import boto3
 import pythena
 
 # Prints out all databases listed in the glue catalog
 pythena.print_databases()
 pythena.print_databases(region='us-east-1') # Overrides default region
+pythena.print_databases(session=boto3.session.Session()) # Overrides default profile
 
 # Gets all databases and returns as a list
 pythena.get_databases()
 pythena.get_databases(region='us-east-1') # Overrides default region
+pythena.get_databases(session=boto3.session.Session()) # Overrides default profile
 
 # Connect to a database
 athena_client = pythena.Athena(database="mydatabase")
+athena_client = pythena.Athena(database="mydatabase", region='us-east-1') # Overrides default region
+athena_client = pythena.Athena(database="mydatabase", session=boto3.session.Session()) # Overrides default profile
 
 # Prints out all tables in a database
 athena_client.print_tables()

--- a/pythena/Athena.py
+++ b/pythena/Athena.py
@@ -33,7 +33,7 @@ class Athena:
         self._athena = session.client('athena', region_name=region)
         self.__s3 = session.client('s3', region_name=region)
         self.__glue = session.client('glue', region_name=region)
-        if database not in Utils.get_databases(session, region):
+        if database not in Utils.get_databases(region=region, session=session):
             raise Exceptions.DatabaseNotFound("Database " + database + " not found.")
 
     def get_tables(self):

--- a/pythena/Athena.py
+++ b/pythena/Athena.py
@@ -24,12 +24,12 @@ class Athena:
 
     def __init__(self, database, region='us-east-1', session=None):
         self.__database = database
-        self.__region = region
         self._session = session if session is not None else boto3.session.Session()
         if region is None:
             region = self._session.region_name
             if region is None:
                 raise Exceptions.NoRegionFoundError("No default aws region configuration found. Must specify a region.")
+        self.__region = region
         self._athena = self._session.client('athena', region_name=region)
         self.__s3 = self._session.client('s3', region_name=region)
         self.__glue = self._session.client('glue', region_name=region)

--- a/pythena/Utils.py
+++ b/pythena/Utils.py
@@ -25,7 +25,7 @@ def get_databases(region=None, session=None):
 def print_databases(region=None, session=None):
     if session is None:
         session = boto3.session.Session()
-    print_list(get_databases(session, region))
+    print_list(get_databases(region=region, session=session))
 
 
 def print_list(_list):

--- a/pythena/Utils.py
+++ b/pythena/Utils.py
@@ -1,8 +1,10 @@
 import boto3
 
 
-def get_databases(region=None):
-    glue = boto3.client('glue', region_name=region)
+def get_databases(region=None, session=None):
+    if session is None:
+        session = boto3.session.Session()
+    glue = session.client('glue', region_name=region)
     databases = []
 
     params = {}
@@ -20,8 +22,10 @@ def get_databases(region=None):
     return databases
 
 
-def print_databases(region=None):
-    print_list(get_databases(region))
+def print_databases(region=None, session=None):
+    if session is None:
+        session = boto3.session.Session()
+    print_list(get_databases(session, region))
 
 
 def print_list(_list):

--- a/pythena/Utils.py
+++ b/pythena/Utils.py
@@ -23,8 +23,6 @@ def get_databases(region=None, session=None):
 
 
 def print_databases(region=None, session=None):
-    if session is None:
-        session = boto3.session.Session()
     print_list(get_databases(region=region, session=session))
 
 


### PR DESCRIPTION
I work with multiple profiles and with this change pythena could be used with custom session objects like this
```python
import boto3
import pythena

sess = boto3.session.Session(profile_name="my_profile")
pythena_client = pythena.Athena("database", session=sess)
```